### PR TITLE
Prevent trailing space in class attribute

### DIFF
--- a/module.js
+++ b/module.js
@@ -47,7 +47,7 @@ M.format_buttons.show = function(id, courseid) {
     this.hide();
     var buttonsection = document.getElementById('buttonsection-' + id);
     var currentsection = document.getElementById('section-' + id);
-    buttonsection.setAttribute('class', buttonsection.getAttribute('class') + ' sectionvisible');
+    buttonsection.setAttribute('class', buttonsection.getAttribute('class').trim() + ' sectionvisible');
     currentsection.style.display = 'block';
     document.cookie = 'sectionvisible_' + courseid + '=' + id + '; path=/';
     M.format_buttons.h5p();


### PR DESCRIPTION
Prevent trailing space in class attribute on Show event. If a user repeatedly clicks on the same section, it creates unnecessary spaces in the class attribute. 

Adding the .trim() function while grabbing the attribute fixes this problem.