### PR TITLE
adiciona format que mostra nome de seção e estilo de botão com canto arredondado

### DIFF
--- a/lang/en/format_buttons.php
+++ b/lang/en/format_buttons.php
@@ -70,5 +70,6 @@ $string['buttonstyle'] = 'Button style';
 $string['buttonstyle_help'] = 'Define the shape style of the buttons.';
 $string['circle'] = 'Circle';
 $string['square'] = 'Square';
+$string['roundedcorners'] = 'Rounded corners';
 $string['inlinesections'] = 'Inline sections';
 $string['inlinesections_help'] = 'Give each section a new line.';

--- a/lib.php
+++ b/lib.php
@@ -219,6 +219,7 @@ class format_buttons extends format_topics {
                         'numeric' => get_string('numeric', 'format_buttons'),
                         'roman' => get_string('roman', 'format_buttons'),
                         'alphabet' => get_string('alphabet', 'format_buttons'),
+                        'sectionname' => get_string('sectionname', 'format_buttons'),
                     ),
                 ),
             );
@@ -231,6 +232,7 @@ class format_buttons extends format_topics {
                     array(
                         'circle' => get_string('circle', 'format_buttons'),
                         'square' => get_string('square', 'format_buttons'),
+                        'roundedcorners' => get_string('roundedcorners', 'format_buttons'),
                     ),
                 ),
             );

--- a/renderer.php
+++ b/renderer.php
@@ -198,6 +198,9 @@ class format_buttons_renderer extends format_topics_renderer
             if ($course->sectiontype == 'roman' && is_numeric($name)) {
                 $name = $this->number_to_roman($name);
             }
+            if ($course->sectiontype == 'sectionname' && is_numeric($name)) {
+                $name = $thissection->name;
+            }
             $class = 'buttonsection';
             $onclick = 'M.format_buttons.show(' . $section . ',' . $course->id . ')';
             if (!$thissection->available &&

--- a/styles.css
+++ b/styles.css
@@ -127,6 +127,13 @@
     color: rgba(0, 0, 0, 0.6);
 }
 
+#buttonsectioncontainer.roundedcorners .buttonsection {
+  height: auto;
+  width: auto;
+  padding: .25em 1em;
+  border-radius: 10px
+}
+
 /* colors */
 #buttonsectioncontainer .buttonsection.current {
     background: #115898;


### PR DESCRIPTION
Oi, Rodrigo!
Fiz para um cliente e acho que pode ser interessante pra mais gente.
A possibilidade de mostrar o nome da seção na lista (ao invés dos números) e também um estilo de botão com cantos arrendondados, que fica melhor que o quadrado e círculo, nesse caso.
Espero que goste.
![Screenshot from 2023-11-13 16-18-36](https://github.com/brandaorodrigo/moodle-format_buttons/assets/17608/d31c0a7d-8d45-4e4c-87d8-971e8b8640b4)

Abração!