### PR TITLE
Issue #56: Added cachedef_user_last_section string

### DIFF
--- a/lang/en/format_buttons.php
+++ b/lang/en/format_buttons.php
@@ -38,6 +38,7 @@ $string['newsectionname'] = 'New name for section {$a}';
 $string['pluginname'] = 'buttons Format';
 $string['sectionname'] = 'Section';
 $string['showfromothers'] = 'Show section';
+$string['cachedef_user_last_section'] = 'User last section cache';
 $string['fontcolor'] = 'Font color';
 $string['fontcolor_desc'] = 'Specify the font color for the buttons';
 $string['config'] = 'Plugin configuration';


### PR DESCRIPTION
Closes issue #56.

Adding this string fixes the unit test failure.

How to replicate: 
1. Deploy local Moodle 4.5 instance with format_buttons installed
2. Initialize PHPUnit test environment
3. Run `vendor/bin/phpunit cache/tests/administration_helper_test.php`
4. See the error message
5. Checkout to `catalyst-master` branch and re-run test
6. See the following output: 
```
Moodle 4.5.2+ (Build: 20250314), dac9c54eb909d102a38809858956255894d95436
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Time: 00:01.071, Memory: 93.00 MB

OK (5 tests, 72 assertions)
```