### PR TITLE
Remove the use of deprecated functions in Moodle 4.4 and above

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -475,7 +475,14 @@ class content extends content_base
      */
     protected function get_sections_to_display(\course_modinfo $modinfo): array
     {
-        $singlesection = $this->format->get_section_number();
+        if (method_exists($this->format, 'get_sectionnum')) {
+            // For Moodle 4.4 and above.
+            $singlesection = $this->format->get_sectionnum() ?? 0;
+        } else {
+            // Backward compatibility for Moodle 4.3 and below.
+            $singlesection = $this->format->get_section_number();
+        }
+
         if ($singlesection) {
             return [
                 $modinfo->get_section_info(0),

--- a/classes/output/courseformat/content/section.php
+++ b/classes/output/courseformat/content/section.php
@@ -62,10 +62,18 @@ class section extends section_base
         $section_numer = $section->section ?? '0';
         $title_section_view = $course->title_section_view;
 
+        if (method_exists($format, 'get_sectionnum')) {
+            // For Moodle 4.4 and above.
+            $sectionreturnid = $format->get_sectionnum() ?? 0;
+        } else {
+            // Backward compatibility for Moodle 4.3 and below.
+            $sectionreturnid = $format->get_section_number();
+        }
+
         $data = (object)[
             'num' => $section_numer,
             'id' => $section->id,
-            'sectionreturnid' => $format->get_section_number(),
+            'sectionreturnid' => $sectionreturnid,
             'insertafter' => false,
             'summary' => $summary->export_for_template($output),
             'highlightedlabel' => $format->get_section_highlighted_name(),

--- a/lib.php
+++ b/lib.php
@@ -27,7 +27,14 @@ class format_buttons extends core_courseformat\base
     protected function __construct($format, $courseid)
     {
         parent::__construct($format, $courseid);
-        $this->set_section_number(false);
+
+        if (method_exists($this, 'set_sectionnum')) {
+            // For Moodle 4.4 and above.
+            $this->set_sectionnum(null);
+        } else {
+            // Backward compatibility for Moodle 4.3 and below.
+            $this->set_section_number(0);
+        }
     }
 
     /**


### PR DESCRIPTION
Since Moodle 4.4, `core_courseformat\base::get_section_number()` and `core_courseformat\base::set_section_number()` are deprecated.

With debug set to DEVELOPER level (`$CFG->debug = 32767;` in `config.php`), you should see few messages about this problem on courses that use button format.

This PR will use `core_courseformat\base::get_sectionnum()` and `core_courseformat\base::set_sectionnum()` for Moodle 4.4 and above.
