### PR TITLE
Fix an uninitialized variable

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -74,9 +74,7 @@ class content extends content_base
             default => "0%",
         };
 
-
-        global $DB;
-
+        $verified_exist = false;
         $section = $this->get_last_section_access();
         if ($section) {
             $verified_exist = $DB->get_record('course_sections', ['section' => $section,


### PR DESCRIPTION
When you access for the first time to a course that uses the buttons format, you have a PHP notice for an uninitialized variable.

This PR should fix this issue.
